### PR TITLE
Auto detect gpu compute arch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,12 +16,12 @@ find_package(MPI REQUIRED)
 find_package(Torch REQUIRED)
 
 if (CUDA_ENABLE)
-        if (NOT TORCH_CUDA_LIBRARIES) 
+        if (NOT DEFINED TORCH_CUDA_LIBRARIES) 
                 message(FATAL_ERROR "libtorch does not support gpu, please download the gpu version of libtorch.")
-        endif (TORCH_CUDA_LIBRARIES)
+        endif()
         add_definitions(-DCUDA_ENABLE)
         add_subdirectory(cuda)
-endif (CUDA_ENABLE)
+endif()
 
 #exec_program("mpic++ -showme:compile" OUTPUT_VARIABLE MPI_COMPILE_FLAGS)
 #exec_program("mpic++ -showme:incdirs" OUTPUT_VARIABLE MPI_INCDIRS)
@@ -122,7 +122,7 @@ if (CUDA_ENABLE)
         target_link_libraries(nts  ${TORCH_LIBRARIES} ${MPI_LIBRARIES} numa ${CUDA_LIBRARIES} cuda_propagate)
 else()
         target_link_libraries(nts  ${TORCH_LIBRARIES} ${MPI_LIBRARIES} numa)
-endif (CUDA_ENABLE)
+endif()
 
 
 add_executable(nts_test ${NEUTRONSTAR_TEST_SRC_FILES})
@@ -130,7 +130,7 @@ if (CUDA_ENABLE)
         target_link_libraries(nts_test  ${TORCH_LIBRARIES} ${MPI_LIBRARIES} numa ${CUDA_LIBRARIES} cuda_propagate)
 else()
         target_link_libraries(nts_test  ${TORCH_LIBRARIES} ${MPI_LIBRARIES} numa)
-endif (CUDA_ENABLE)
+endif()
 
 
 # quick test for debugging purpose

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,16 +9,20 @@ list(APPEND CMAKE_PREFIX_PATH "./GPU_libtorch/libtorch-1-9/libtorch/")
 project(GNNmini)
 set(ENV{LANG} "C")
 option (CUDA_ENABLE "DEFAULT ENABLE CUDA" ON)
-message(STATUS "NeutronStar buid with CUDA " ${CUDA_ENABLE})
+message(STATUS "NeutronStar buid with CUDA ${CUDA_ENABLE}")
 
 find_package(PythonInterp REQUIRED)
 find_package(MPI REQUIRED)
-# because torch also depends on cuda, so we find cuda first
-if (CUDA_ENABLE)
-        add_definitions(-DCUDA_ENABLE)
-        find_package(CUDA REQUIRED)
-endif (CUDA_ENABLE)
 find_package(Torch REQUIRED)
+
+if (CUDA_ENABLE)
+        if (NOT TORCH_CUDA_LIBRARIES) 
+                message(FATAL_ERROR "libtorch does not support gpu, please download the gpu version of libtorch.")
+        endif (TORCH_CUDA_LIBRARIES)
+        add_definitions(-DCUDA_ENABLE)
+        add_subdirectory(cuda)
+endif (CUDA_ENABLE)
+
 #exec_program("mpic++ -showme:compile" OUTPUT_VARIABLE MPI_COMPILE_FLAGS)
 #exec_program("mpic++ -showme:incdirs" OUTPUT_VARIABLE MPI_INCDIRS)
 #exec_program("mpic++ -showme:link" OUTPUT_VARIABLE MPI_LINK_FLAGS)
@@ -84,11 +88,6 @@ add_custom_target(format ${NEUTRONSTAR_BUILD_SUPPORT_DIR}/run_clang_format.py
         # --quiet
         )
 
-if (CUDA_ENABLE)
-        add_subdirectory(cuda)
-        set(EXTRA_LIBS ${EXTRA_LIBS} cuda_propagate)
-endif (CUDA_ENABLE)
-
 include_directories(
 ${CMAKE_CURRENT_SOURCE_DIR}
 ./core
@@ -120,7 +119,7 @@ set(NEUTRONSTAR_TEST_SRC_FILES
 
 add_executable(nts ${NEUTRONSTAR_SRC_FILES})
 if (CUDA_ENABLE)
-        target_link_libraries(nts  ${TORCH_LIBRARIES} ${MPI_LIBRARIES} ${EXTRA_LIBS} ${CUDA_LIBRARIES} cuda_propagate numa)
+        target_link_libraries(nts  ${TORCH_LIBRARIES} ${MPI_LIBRARIES} numa ${CUDA_LIBRARIES} cuda_propagate)
 else()
         target_link_libraries(nts  ${TORCH_LIBRARIES} ${MPI_LIBRARIES} numa)
 endif (CUDA_ENABLE)
@@ -128,12 +127,10 @@ endif (CUDA_ENABLE)
 
 add_executable(nts_test ${NEUTRONSTAR_TEST_SRC_FILES})
 if (CUDA_ENABLE)
-        target_link_libraries(nts_test  ${TORCH_LIBRARIES} ${MPI_LIBRARIES} ${EXTRA_LIBS} ${CUDA_LIBRARIES} cuda_propagate numa)
+        target_link_libraries(nts_test  ${TORCH_LIBRARIES} ${MPI_LIBRARIES} numa ${CUDA_LIBRARIES} cuda_propagate)
 else()
         target_link_libraries(nts_test  ${TORCH_LIBRARIES} ${MPI_LIBRARIES} numa)
 endif (CUDA_ENABLE)
-
-
 
 
 # quick test for debugging purpose

--- a/core/ntsBaseOp.hpp
+++ b/core/ntsBaseOp.hpp
@@ -64,18 +64,26 @@ inline void nts_comp_non_avx256(ValueType *output, ValueType *input, ValueType w
 //avx256
 inline void nts_comp(ValueType *output, ValueType *input, ValueType weight,
           int feat_size) { 
-    const int LEN=8;
+#ifdef __AVX__  // support AVX   
+  // printf("use avx version nts_comp\n");
+  const int LEN=8;
   int loop=feat_size/LEN;
   int res=feat_size%LEN;
   __m256 w=_mm256_broadcast_ss(reinterpret_cast<float const *>(&weight));
   for(int i=0;i<loop;i++){
-    __m256 source= *reinterpret_cast<__m256 *>(&(input[i*LEN]));
+    __m256 source= _mm256_loadu_ps(reinterpret_cast<float const *>(&(input[i*LEN])));
     __m256 destination= _mm256_loadu_ps(reinterpret_cast<float const *>(&(output[i*LEN])));
     _mm256_storeu_ps(&(output[i*LEN]),_mm256_add_ps(_mm256_mul_ps(source,w),destination));
   }
   for (int i = LEN*loop; i < feat_size; i++) {
     output[i] += input[i] * weight;
   }
+#else // not support AVX
+  // printf("use normal version nts_comp\n");
+  for (int i = 0; i < feat_size; i++) {
+    output[i] += input[i] * weight;
+  }
+#endif
 }
 
 

--- a/cuda/CMakeLists.txt
+++ b/cuda/CMakeLists.txt
@@ -4,11 +4,11 @@ find_package(CUDA REQUIRED)
  
 file(GLOB_RECURSE CURRENT_HEADERS &.hpp *.cuh *.h)
 file(GLOB CURRENT_SOURCES *.cu *.cpp)
- 
-set(CUDA_NVCC_FLAGS -gencode arch=compute_61,code=sm_61;-O3;-G;-g)
 
-list(APPEND CUDA_NVCC_FLAGS "-std=c++14")
- 
+cuda_select_nvcc_arch_flags(ARCH_FLAGS)
+set(CUDA_NVCC_FLAGS "${ARCH_FLAGS} -std=c++14 -O3 -G -g")
+message(STATUS "CUDA_NVCC_FLAGS: ${CUDA_NVCC_FLAGS}" )
+
 source_group("Include" FILES ${CURRENT_HEADERS})
 source_group("Source" FILES ${CURRENT_SOURCES})
  


### PR DESCRIPTION
完善CMake配置：
1. 删除一些冗余的判断。
2. 使用cuda_select_nvcc_arch_flags在运行时得到gpu的计算架构。（https://cmake.org/cmake/help/latest/module/FindCUDA.html#commands）